### PR TITLE
Add formatted Discord notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# jira-discord-webhook
+# Jira Discord Webhook
+
+This project provides a small HTTP server written in Go that receives Jira webhook events and forwards them to a Discord webhook.
+The server formats issue updates, comments, and transitions into Discord embeds so you can easily track activity from Jira.
+
+## Building
+
+```bash
+go build
+```
+
+## Running
+
+Set the `DISCORD_WEBHOOK_URL` environment variable to your Discord webhook and start the server:
+
+```bash
+export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+go run .
+```
+
+Set `JIRA_BASE_URL` to the base URL for your Jira instance so links in Discord messages work correctly:
+
+```bash
+export JIRA_BASE_URL="https://your-company.atlassian.net/browse"
+```
+
+The server listens on port `8080` by default. You can override this by setting the `PORT` environment variable.
+
+Jira should be configured to send webhooks to `http://your-server:8080/webhook`.
+
+Issue comments will appear in Discord with the comment text and author.
+When an issue transitions between statuses, the change will be included in the notification.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module jira-discord-webhook
+
+go 1.23.8

--- a/main.go
+++ b/main.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type JiraIssue struct {
+	Key    string `json:"key"`
+	Fields struct {
+		Summary     string `json:"summary"`
+		Description string `json:"description"`
+		Priority    struct {
+			Name string `json:"name"`
+		} `json:"priority"`
+		Assignee struct {
+			DisplayName string `json:"displayName"`
+		} `json:"assignee"`
+		Issuetype struct {
+			Name string `json:"name"`
+		} `json:"issuetype"`
+		Status struct {
+			Name string `json:"name"`
+		} `json:"status"`
+	} `json:"fields"`
+}
+
+type JiraComment struct {
+	Body   string `json:"body"`
+	Author struct {
+		DisplayName string `json:"displayName"`
+	} `json:"author"`
+}
+
+type JiraChangelogItem struct {
+	Field      string `json:"field"`
+	FromString string `json:"fromString"`
+	ToString   string `json:"toString"`
+}
+
+type JiraChangelog struct {
+	Items []JiraChangelogItem `json:"items"`
+}
+
+type JiraWebhook struct {
+	Issue     JiraIssue      `json:"issue"`
+	Comment   *JiraComment   `json:"comment,omitempty"`
+	Changelog *JiraChangelog `json:"changelog,omitempty"`
+}
+
+type DiscordWebhookMessage struct {
+	Username string         `json:"username,omitempty"`
+	Embeds   []DiscordEmbed `json:"embeds"`
+}
+
+type DiscordEmbed struct {
+	Title       string         `json:"title"`
+	URL         string         `json:"url,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Fields      []DiscordField `json:"fields,omitempty"`
+}
+
+type DiscordField struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline bool   `json:"inline"`
+}
+
+func sendToDiscord(msg DiscordWebhookMessage) error {
+	webhookURL := os.Getenv("DISCORD_WEBHOOK_URL")
+	if webhookURL == "" {
+		return fmt.Errorf("DISCORD_WEBHOOK_URL not set")
+	}
+
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Post(webhookURL, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("discord webhook returned status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func webhookHandler(w http.ResponseWriter, r *http.Request) {
+	var payload JiraWebhook
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		log.Println("failed to decode jira payload:", err)
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	baseURL := os.Getenv("JIRA_BASE_URL")
+	issueURL := ""
+	if baseURL != "" {
+		issueURL = fmt.Sprintf("%s/%s", strings.TrimRight(baseURL, "/"), payload.Issue.Key)
+	}
+
+	embed := DiscordEmbed{
+		Title: fmt.Sprintf("%s: %s", payload.Issue.Key, payload.Issue.Fields.Summary),
+		URL:   issueURL,
+	}
+
+	// Use issue description by default
+	embed.Description = payload.Issue.Fields.Description
+
+	if payload.Comment != nil {
+		embed.Description = payload.Comment.Body
+		embed.Fields = append(embed.Fields, DiscordField{
+			Name:   "Comment by",
+			Value:  payload.Comment.Author.DisplayName,
+			Inline: true,
+		})
+	}
+
+	if payload.Changelog != nil {
+		for _, item := range payload.Changelog.Items {
+			if strings.ToLower(item.Field) == "status" {
+				embed.Fields = append(embed.Fields, DiscordField{
+					Name:  "Transition",
+					Value: fmt.Sprintf("%s → %s", item.FromString, item.ToString),
+				})
+				break
+			}
+		}
+	}
+
+	embed.Fields = append(embed.Fields, DiscordField{Name: "Priority", Value: payload.Issue.Fields.Priority.Name, Inline: true})
+	embed.Fields = append(embed.Fields, DiscordField{Name: "Assignee", Value: payload.Issue.Fields.Assignee.DisplayName, Inline: true})
+	embed.Fields = append(embed.Fields, DiscordField{Name: "Status", Value: payload.Issue.Fields.Status.Name, Inline: true})
+	embed.Fields = append(embed.Fields, DiscordField{Name: "Type", Value: payload.Issue.Fields.Issuetype.Name, Inline: true})
+
+	msg := DiscordWebhookMessage{
+		Username: "Jira",
+		Embeds:   []DiscordEmbed{embed},
+	}
+
+	if err := sendToDiscord(msg); err != nil {
+		log.Println("failed to send to discord:", err)
+		http.Error(w, "failed to send to discord", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func main() {
+	http.HandleFunc("/webhook", webhookHandler)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Println("Listening on :" + port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}


### PR DESCRIPTION
## Summary
- add JIRA_BASE_URL instructions
- include priority, assignee, status and type in Discord embeds
- build issue link when sending messages
- handle comments and issue transitions

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856b6eaa8d88328ad4f5c1c314a7b4b