### PR TITLE
Implement webhook method validation and multiarch Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM golang:1.21 AS builder
+WORKDIR /src
+COPY go.mod .
+RUN go mod download
+COPY . .
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} go build -o /out/app
+
+FROM --platform=$TARGETPLATFORM alpine:3.18
+WORKDIR /
+COPY --from=builder /out/app /app
+EXPOSE 8080
+ENTRYPOINT ["/app"]
+

--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ Jira should be configured to send webhooks to `http://your-server:8080/webhook`.
 Issue comments will appear in Discord with the comment text and author.
 When an issue transitions between statuses, the change will be included in the notification.
 If a webhook contains multiple field updates, all of the changes are summarized in a single Discord message so you can see everything that changed at a glance.
+
+## Docker
+
+This repository includes a multi-architecture `Dockerfile`. Build images for multiple platforms with Docker Buildx:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t my/jira-hook .
+```
+
+Run the resulting image by providing the required environment variables:
+
+```bash
+docker run -e DISCORD_WEBHOOK_URL=... -p 8080:8080 my/jira-hook
+```


### PR DESCRIPTION
## Summary
- replace deprecated ioutil and strings title functions
- validate POST requests in the webhook handler
- support multi-arch builds with new Dockerfile
- document docker build and run steps

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857e1010e00832893bc09cb58c7cb42