### PR TITLE
Add Jira payload unit tests and Postman collection

### DIFF
--- a/internal/jira/convert_test.go
+++ b/internal/jira/convert_test.go
@@ -1,0 +1,84 @@
+package jira
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func loadWebhook(t *testing.T, name string) Webhook {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	var w Webhook
+	if err := json.Unmarshal(b, &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return w
+}
+
+func TestToDiscordMessageIssue(t *testing.T) {
+	w := loadWebhook(t, "issue.json")
+	msg := ToDiscordMessage(w, "https://example.com/browse")
+	if msg.Embeds[0].Title != "PRJ-1: Test issue" {
+		t.Fatalf("unexpected title: %s", msg.Embeds[0].Title)
+	}
+	if msg.Embeds[0].URL != "https://example.com/browse/PRJ-1" {
+		t.Fatalf("unexpected url: %s", msg.Embeds[0].URL)
+	}
+}
+
+func TestToDiscordMessageComment(t *testing.T) {
+	w := loadWebhook(t, "comment.json")
+	msg := ToDiscordMessage(w, "")
+	if msg.Embeds[0].Description != "looks good" {
+		t.Fatalf("expected comment body")
+	}
+	var found bool
+	for _, f := range msg.Embeds[0].Fields {
+		if f.Name == "Comment by" && f.Value == "Alice" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing comment author field")
+	}
+}
+
+func TestToDiscordMessageChangelog(t *testing.T) {
+	w := loadWebhook(t, "changelog.json")
+	msg := ToDiscordMessage(w, "")
+	var found bool
+	for _, f := range msg.Embeds[0].Fields {
+		if f.Name == "Changes" &&
+			f.Value == "Status: Open → Closed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected status change field")
+	}
+}
+
+func TestToDiscordMessageCommentChangelog(t *testing.T) {
+	w := loadWebhook(t, "comment_changelog.json")
+	msg := ToDiscordMessage(w, "")
+	if msg.Embeds[0].Description != "needs work" {
+		t.Fatalf("expected comment body")
+	}
+	var hasAuthor, hasChange bool
+	for _, f := range msg.Embeds[0].Fields {
+		if f.Name == "Comment by" && f.Value == "Alice" {
+			hasAuthor = true
+		}
+		if f.Name == "Changes" && f.Value == "Status: Open → Closed" {
+			hasChange = true
+		}
+	}
+	if !hasAuthor || !hasChange {
+		t.Fatalf("expected comment author and change fields")
+	}
+}

--- a/internal/jira/testdata/changelog.json
+++ b/internal/jira/testdata/changelog.json
@@ -1,0 +1,18 @@
+{
+  "issue": {
+    "key": "PRJ-3",
+    "fields": {
+      "summary": "Change",
+      "description": "desc",
+      "priority": {"name": "High"},
+      "assignee": {"displayName": "Bob"},
+      "issuetype": {"name": "Task"},
+      "status": {"name": "Closed"}
+    }
+  },
+  "changelog": {
+    "items": [
+      {"field": "status", "fromString": "Open", "toString": "Closed"}
+    ]
+  }
+}

--- a/internal/jira/testdata/comment.json
+++ b/internal/jira/testdata/comment.json
@@ -1,0 +1,17 @@
+{
+  "issue": {
+    "key": "PRJ-2",
+    "fields": {
+      "summary": "Commented",
+      "description": "desc",
+      "priority": {"name": "High"},
+      "assignee": {"displayName": "Bob"},
+      "issuetype": {"name": "Task"},
+      "status": {"name": "Open"}
+    }
+  },
+  "comment": {
+    "body": "looks good",
+    "author": {"displayName": "Alice"}
+  }
+}

--- a/internal/jira/testdata/comment_changelog.json
+++ b/internal/jira/testdata/comment_changelog.json
@@ -1,0 +1,22 @@
+{
+  "issue": {
+    "key": "PRJ-4",
+    "fields": {
+      "summary": "Comment and Change",
+      "description": "desc",
+      "priority": {"name": "High"},
+      "assignee": {"displayName": "Bob"},
+      "issuetype": {"name": "Task"},
+      "status": {"name": "Closed"}
+    }
+  },
+  "comment": {
+    "body": "needs work",
+    "author": {"displayName": "Alice"}
+  },
+  "changelog": {
+    "items": [
+      {"field": "status", "fromString": "Open", "toString": "Closed"}
+    ]
+  }
+}

--- a/internal/jira/testdata/issue.json
+++ b/internal/jira/testdata/issue.json
@@ -1,0 +1,13 @@
+{
+  "issue": {
+    "key": "PRJ-1",
+    "fields": {
+      "summary": "Test issue",
+      "description": "desc",
+      "priority": {"name": "High"},
+      "assignee": {"displayName": "Bob"},
+      "issuetype": {"name": "Task"},
+      "status": {"name": "Open"}
+    }
+  }
+}

--- a/postman/jira-discord-webhook.postman_collection.json
+++ b/postman/jira-discord-webhook.postman_collection.json
@@ -1,0 +1,45 @@
+{
+  "info": {
+    "_postman_id": "1427d125-0355-4100-adcc-7d0a41ac9f14",
+    "name": "Jira Discord Webhook Tests",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Issue Event",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Content-Type", "value": "application/json"}
+        ],
+        "url": {"raw": "{{base_url}}/webhook", "host": ["{{base_url}}"], "path": ["webhook"]},
+        "body": {"mode": "raw", "raw": "{"issue":{"key":"PRJ-1","fields":{"summary":"Test issue","description":"desc","priority":{"name":"High"},"assignee":{"displayName":"Bob"},"issuetype":{"name":"Task"},"status":{"name":"Open"}}}}"}
+      },
+      "event": [{"listen": "test", "script": {"exec": ["pm.test(\"Status code is 200\", function () {", "    pm.response.to.have.status(200);", "});"]}}]
+    },
+    {
+      "name": "Comment Event",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Content-Type", "value": "application/json"}
+        ],
+        "url": {"raw": "{{base_url}}/webhook", "host": ["{{base_url}}"], "path": ["webhook"]},
+        "body": {"mode": "raw", "raw": "{"issue":{"key":"PRJ-2","fields":{"summary":"Commented","description":"desc","priority":{"name":"High"},"assignee":{"displayName":"Bob"},"issuetype":{"name":"Task"},"status":{"name":"Open"}}},"comment":{"body":"looks good","author":{"displayName":"Alice"}}}"}
+      },
+      "event": [{"listen": "test", "script": {"exec": ["pm.test(\"Status code is 200\", function () {", "    pm.response.to.have.status(200);", "});"]}}]
+    },
+    {
+      "name": "Changelog Event",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Content-Type", "value": "application/json"}
+        ],
+        "url": {"raw": "{{base_url}}/webhook", "host": ["{{base_url}}"], "path": ["webhook"]},
+        "body": {"mode": "raw", "raw": "{"issue":{"key":"PRJ-3","fields":{"summary":"Change","description":"desc","priority":{"name":"High"},"assignee":{"displayName":"Bob"},"issuetype":{"name":"Task"},"status":{"name":"Closed"}}},"changelog":{"items":[{"field":"status","fromString":"Open","toString":"Closed"}]}}"}
+      },
+      "event": [{"listen": "test", "script": {"exec": ["pm.test(\"Status code is 200\", function () {", "    pm.response.to.have.status(200);", "});"]}}]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add JSON fixtures for different Jira webhook payloads
- create unit tests covering conversions for each payload
- generate a Postman collection to replay the payloads

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857fdba6a1c83288af8619b1bd01bf0