### PR TITLE
Add coverage tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,15 @@ jobs:
       - name: Run tests
         id: tests
         run: |
-          go test ./... | tee /tmp/test.log
+          go test ./... -coverprofile=coverage.out | tee /tmp/test.log
+          go tool cover -func=coverage.out | tee -a /tmp/test.log
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out
 
       - name: Add test summary
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate release notes
+        id: cliff
+        uses: orhun/git-cliff-action@v2
+        with:
+          config: cliff.toml
+          output: release.md
+
+      - name: Set tag name
+        id: vars
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=main" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: release.md
+          tag_name: ${{ steps.vars.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ docker run -e DISCORD_WEBHOOK_URL=... -p 8080:8080 my/jira-hook
 The `postman` directory contains a collection with example webhook requests.
 Import `postman/jira-discord-webhook.postman_collection.json` into Postman to
 manually trigger the server with sample issue, comment, and changelog payloads.
+
+## Releases
+
+This project automatically generates release notes using [git-cliff](https://github.com/orhun/git-cliff) whenever changes are pushed to the `main` branch or a tag is created.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,8 @@
+[changelog]
+header = ""
+body = ""
+trim = true
+
+[git]
+conventional_commits = true
+tag_pattern = ".*"

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  jira-discord-webhook:
+    image: ghcr.io/visualizeq/jira-discord-webhook:develop
+    environment:
+      - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
+      - JIRA_BASE_URL=${JIRA_BASE_URL}
+      - PORT=${PORT:-8080}
+      - ISSUE_COLOR=${ISSUE_COLOR-0x00B0F4}
+      - COMMENT_COLOR=${COMMENT_COLOR-0x347433}
+      - CHANGELOG_COLOR=${CHANGELOG_COLOR-0xFF6F3C}
+      - COMMENT_CHANGELOG_COLOR=${COMMENT_CHANGELOG_COLOR-0x5409DA}
+    ports:
+      - "${PORT:-8080}:8080"
+    restart: always

--- a/internal/discord/send_test.go
+++ b/internal/discord/send_test.go
@@ -1,0 +1,49 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestSendWebhookMissingURL(t *testing.T) {
+	os.Unsetenv("DISCORD_WEBHOOK_URL")
+	err := SendWebhook(WebhookMessage{Username: "bot"})
+	if err == nil {
+		t.Fatalf("expected error for missing url")
+	}
+}
+
+func TestSendWebhookHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	os.Setenv("DISCORD_WEBHOOK_URL", srv.URL)
+	err := SendWebhook(WebhookMessage{Username: "bot"})
+	if err == nil {
+		t.Fatalf("expected error from discord server")
+	}
+}
+
+func TestSendWebhookSuccess(t *testing.T) {
+	var body WebhookMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	os.Setenv("DISCORD_WEBHOOK_URL", srv.URL)
+	msg := WebhookMessage{Username: "bot"}
+	if err := SendWebhook(msg); err != nil {
+		t.Fatalf("SendWebhook: %v", err)
+	}
+	if body.Username != "bot" {
+		t.Fatalf("expected username 'bot'")
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for the Discord webhook sender
- upload coverage artifacts in the build workflow
- automate release creation with git-cliff

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685825cbea548328a99b42c01e96f144