### PR TITLE
Align release workflow with docker publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,24 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - '*'
+  workflow_run:
+    workflows: ["Build and Push Docker Image"]
+    types:
+      - completed
 
 permissions:
   contents: write
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Generate release notes
         id: cliff
@@ -24,14 +27,19 @@ jobs:
           config: cliff.toml
           output: release.md
 
+      - name: Check release notes
+        run: test -f release.md
+
       - name: Set tag name
         id: vars
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          git fetch --tags
+          if git describe --tags --exact-match >/dev/null 2>&1; then
+            TAG=$(git describe --tags --exact-match)
           else
-            echo "tag=main" >> "$GITHUB_OUTPUT"
+            TAG=main
           fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Create release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- trigger release workflow after docker build and push completes
- check that release notes exist before creating a release
- resolve tag based on current commit when generating release

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858397e85a48328bd891a4ad084f41c